### PR TITLE
Multilines in DESCRIPTION are not supported

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -202,6 +202,13 @@ class ICal
      */
     protected function unfold(array $lines)
     {
+        for($i = 0; $i < count($lines); $i++){ // Merge multi line values to a singe line
+            if($lines[$i][0] == ' '){
+                $lines[$i-1] = $lines[$i-1] . trim($lines[$i]);
+                $lines[$i] = "";
+            }
+        }   
+        
         $string = implode(PHP_EOL, $lines);
         $string = preg_replace('/' . PHP_EOL . '[ \t]/', '', $string);
         $lines  = explode(PHP_EOL, $string);


### PR DESCRIPTION
DESCRIPTIONS (and maybe other fields) can be on multiple lines.
A 2nd or later line always starts with a whitespace.
Example event:
```
BEGIN:VEVENT
ORGANIZER:MAILTO:info@example.com
SUMMARY:my summary
UID:1234567
DTSTAMP:20170117T102814Z
LAST-MODIFIED:20170117T124845Z
CREATED:20170117T124845Z
DTSTART:20170314T053000Z
DTEND:20170314T063000Z
DESCRIPTION:A very long description split onto multiple lines. The sec
 ond line starts with a whitespace.
END:VEVENT
```
Note that the line break can be within a single word.

The current code only uses the first line of a multiline value.

This Patch fixes this.