### PR TITLE
[FIX] adds a check if the TZID provided via an event is valid

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -688,7 +688,11 @@ class ICal
 
         // Force time zone
         if (isset($dateArray[0]['TZID'])) {
-            $dateTime->setTimezone(new \DateTimeZone($dateArray[0]['TZID']));
+            if($this->isValidTimeZoneId($dateArray[0]['TZID'])){
+                $dateTime->setTimezone(new \DateTimeZone($dateArray[0]['TZID']));
+            }else{
+                $dateTime->setTimezone($this->defaultTimeZone);
+            }
         }
 
         if (is_null($format)) {


### PR DESCRIPTION
As mentioned at https://github.com/u01jmg3/ics-parser/commit/668ea0477d3289104e04e71ad63db5a397b2a15d I wasn't able to parse my ICS files containing a non-valid DateTimeZoneId `W. Europe Standard Time` with https://github.com/u01jmg3/ics-parser/tree/v2.0.6, which reopened #116 for me. Since I assume that all changes were done on purpose and there was no mismatch between my composer-installed package and the v2.0.6 release I'm trying to offer this (hopefully none-intrusive) pull request!
Any feedback is much appreciated, since I don't have a lot of experience with pull requests at all!
Best regards 
