### PR TITLE
Fix for initializing via array of lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^3.0",
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -226,7 +226,7 @@ class ICal
             $files = is_array($files) ? $files : array($files);
 
             foreach ($files as $file) {
-                if ($this->isFileOrUrl($file)) {
+                if (!is_array($file) && $this->isFileOrUrl($file)) {
                     $lines = $this->fileOrUrl($file);
                 } else {
                     $lines = is_array($file) ? $file : array($file);

--- a/test/ICalTest.php
+++ b/test/ICalTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use ICal\ICal;
+
+class ICalTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Confirms that the library can be initialized by passing in an array
+     * of parsed ICalendar data
+     */
+    public function testInitializeFromArrayOfLines()
+    {
+        $lines = [
+            [
+                'BEGIN:VCALENDAR',
+                'END:VCALENDAR'
+            ]
+        ];
+
+        $ical = new ICal($lines);
+    }
+
+}


### PR DESCRIPTION
I noticed that you can't initialize the ICal library using an array of pre-parsed data because it treats it as a file.

I also included a PHPUnit test case, which I realize is a little bit over zealous but I wanted to make sure I could demonstrate the bug and fix. Feel free to close this is you'd rather just apply the fix directly 