### PR TITLE
Add configurable option to disable character replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ var_dump($event->dtstart_array);
 
 | Name                     | Description                                                         | Configurable       | Default Value  |
 |--------------------------|---------------------------------------------------------------------|:------------------:|----------------|
-| `$cal`                   | The parsed calendar                                                 |         :x:        | N/A            |
-| `$alarmCount`            | Tracks the number of alarms in the current iCal feed                |         :x:        | N/A            |
-| `$eventCount`            | Tracks the number of events in the current iCal feed                |         :x:        | N/A            |
-| `$freeBusyCount`         | Tracks the free/busy count in the current iCal feed                 |         :x:        | N/A            |
-| `$todoCount`             | Tracks the number of todos in the current iCal feed                 |         :x:        | N/A            |
-| `$defaultSpan`           | The value in years to use for indefinite, recurring events          | :white_check_mark: | `2`            |
-| `$defaultTimeZone`       | Enables customisation of the default time zone                      | :white_check_mark: | System default |
-| `$defaultWeekStart`      | The two letter representation of the first day of the week          | :white_check_mark: | `MO`           |
-| `$skipRecurrence`        | Toggles whether to skip the parsing of recurrence rules             | :white_check_mark: | `false`        |
-| `$useTimeZoneWithRRules` | Toggles whether to use time zone info when parsing recurrence rules | :white_check_mark: | `false`        |
+| `$cal`                            | The parsed calendar                                                 |         :x:        | N/A            |
+| `$alarmCount`                     | Tracks the number of alarms in the current iCal feed                |         :x:        | N/A            |
+| `$eventCount`                     | Tracks the number of events in the current iCal feed                |         :x:        | N/A            |
+| `$freeBusyCount`                  | Tracks the free/busy count in the current iCal feed                 |         :x:        | N/A            |
+| `$todoCount`                      | Tracks the number of todos in the current iCal feed                 |         :x:        | N/A            |
+| `$defaultSpan`                    | The value in years to use for indefinite, recurring events          | :white_check_mark: | `2`            |
+| `$defaultTimeZone`                | Enables customisation of the default time zone                      | :white_check_mark: | System default |
+| `$defaultWeekStart`               | The two letter representation of the first day of the week          | :white_check_mark: | `MO`           |
+| `$skipRecurrence`                 | Toggles whether to skip the parsing of recurrence rules             | :white_check_mark: | `false`        |
+| `$useTimeZoneWithRRules`          | Toggles whether to use time zone info when parsing recurrence rules | :white_check_mark: | `false`        |
+| `$disableCharacterReplacement`    | Toggles whether to disable all character replacement                | :white_check_mark: | `false`        |
 
 #### Methods
 

--- a/examples/index.php
+++ b/examples/index.php
@@ -10,6 +10,7 @@ try {
         'defaultWeekStart'      => 'MO',  // Default value
         'skipRecurrence'        => false, // Default value
         'useTimeZoneWithRRules' => false, // Default value
+        'disableCharacterReplacement' => false //Default value
     ));
     // $ical->initFile('ICal.ics');
     // $ical->initUrl('https://raw.githubusercontent.com/u01jmg3/ics-parser/master/examples/ICal.ics');

--- a/examples/index.php
+++ b/examples/index.php
@@ -5,12 +5,12 @@ use ICal\ICal;
 
 try {
     $ical = new ICal('ICal.ics', array(
-        'defaultSpan'           => 2,     // Default value
-        'defaultTimeZone'       => 'UTC',
-        'defaultWeekStart'      => 'MO',  // Default value
-        'skipRecurrence'        => false, // Default value
-        'useTimeZoneWithRRules' => false, // Default value
-        'disableCharacterReplacement' => false //Default value
+        'defaultSpan'                   => 2,     // Default value
+        'defaultTimeZone'               => 'UTC',
+        'defaultWeekStart'              => 'MO',  // Default value
+        'disableCharacterReplacement'   => false, //Default value
+        'skipRecurrence'                => false, // Default value
+        'useTimeZoneWithRRules'         => false, // Default value
     ));
     // $ical->initFile('ICal.ics');
     // $ical->initUrl('https://raw.githubusercontent.com/u01jmg3/ics-parser/master/examples/ICal.ics');

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -90,6 +90,13 @@ class ICal
     public $useTimeZoneWithRRules = false;
 
     /**
+     * Toggles whether to disable all character replacement.
+     *
+     * @var boolean
+     */
+    public $disableCharacterReplacement = false;
+
+    /**
      * The parsed calendar
      *
      * @var array
@@ -207,6 +214,7 @@ class ICal
         'defaultWeekStart',
         'skipRecurrence',
         'useTimeZoneWithRRules',
+        'disableCharacterReplacement'
     );
 
     /**
@@ -314,7 +322,7 @@ class ICal
             foreach ($lines as $line) {
                 $line = rtrim($line); // Trim trailing whitespace
                 $line = $this->removeUnprintableChars($line);
-                $line = $this->cleanData($line);
+                if (!$this->disableCharacterReplacement) $line = $this->cleanData($line);
                 $add  = $this->keyValueFromString($line);
 
                 $keyword = $add[0];

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -212,9 +212,9 @@ class ICal
         'defaultSpan',
         'defaultTimeZone',
         'defaultWeekStart',
+        'disableCharacterReplacement',
         'skipRecurrence',
         'useTimeZoneWithRRules',
-        'disableCharacterReplacement'
     );
 
     /**
@@ -322,8 +322,10 @@ class ICal
             foreach ($lines as $line) {
                 $line = rtrim($line); // Trim trailing whitespace
                 $line = $this->removeUnprintableChars($line);
-                if (!$this->disableCharacterReplacement) $line = $this->cleanData($line);
-                $add  = $this->keyValueFromString($line);
+                if (!$this->disableCharacterReplacement) {
+                    $line = $this->cleanData($line);
+                }
+                $add = $this->keyValueFromString($line);
 
                 $keyword = $add[0];
                 $values  = $add[1]; // May be an array containing multiple values


### PR DESCRIPTION
This PR adds an option to disable character replacement, which brings significant performance improvements. This creates a configurable option `disableCharacterReplacement` which is disabled by default for backwards compatibility. When it is enabled the `cleanData` method will not be called. In Xdebug profiling this has approximately a 4x performance improvement as tested with several calendars with > 500 events. This is predominantly by removing calls to the mb_* functions which can be expensive.

When running the examples, the only change in output is the title and description of the event with special characters. There is no effect on the correct parsing of fields for any of the events.