### PR TITLE
Start using UTC timestamps when comparing dates

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -825,7 +825,7 @@ class ICal
                         $date = sprintf(self::ICAL_DATE_TIME_TEMPLATE, $anEvent[$type . '_array'][0]['TZID']) . $date;
                     }
 
-                    $anEvent[$type . '_array'][2] = $this->iCalDateToUnixTimestamp($date);
+                    $anEvent[$type . '_array'][2] = $this->iCalDateToUnixTimestamp($date, true, true);
                     $anEvent[$type . '_array'][3] = $date;
                 }
             }


### PR DESCRIPTION
Resolves #176

Makes date comparisons more dependable by changing the values of `{DTSTART|DTEND|RECURRENCE-ID}_array[2]`.