### PR TITLE
Add nesbot/carbon ^2.0 as alternative requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-mbstring": "*",
-        "nesbot/carbon": "~1.34"
+        "nesbot/carbon": "~1.34 || ^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.9.1"


### PR DESCRIPTION
Hey,

So I was adding this library to Laravel 5.8 which has a dependency for `"nesbot/carbon": "^1.26.3 || ^2.0"` as I checked how carbon was used in this package I saw nothing that could break by adding an alternative requirement for version 2.0 of carbon.

Cheers!