### PR TITLE
Fix filter days before and after issue

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -711,7 +711,7 @@ class ICal
             $lastIndex = sizeof($events) - 1;
             $lastEvent = $events[$lastIndex];
 
-            if (!isset($lastEvent['RRULE']) || $lastEvent['RRULE'] === '' && $this->doesEventStartOutsideWindow($lastEvent)) {
+            if ((!isset($lastEvent['RRULE']) || $lastEvent['RRULE'] === '') && $this->doesEventStartOutsideWindow($lastEvent)) {
                 $this->eventCount--;
 
                 unset($events[$lastIndex]);
@@ -732,6 +732,11 @@ class ICal
 
         if (!empty($events)) {
             foreach ($events as $key => $anEvent) {
+                if ($anEvent === null) {
+                    unset($events[$key]);
+                    continue;
+                }
+
                 if ($this->doesEventStartOutsideWindow($anEvent)) {
                     $this->eventCount--;
 


### PR DESCRIPTION
#216

When using the before and after filter events inside the range were removed, I had to update 1 line and add an extra check (parentheses) to make it work.

I changed this line in `removeLastEventIfOutsideWindowAndNonRecurring()`

- `if (!isset($lastEvent['RRULE']) || $lastEvent['RRULE'] === '' && $this->doesEventStartOutsideWindow($lastEvent)) {`

to

- `if ((!isset($lastEvent['RRULE']) || $lastEvent['RRULE'] === '') && $this->doesEventStartOutsideWindow($lastEvent)) {`

and had to add this if to the `$events` `foreach` in `reduceEventsToMinMaxRange()`

```php
if ($anEvent === null) {
    unset($events[$key]);
    continue;
}
```

I'm using `v2.1.11`