### PR TITLE
Limit until RRULE if it goes over the default span

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1309,6 +1309,9 @@ class ICal
                     if (isset($rrules['UNTIL'])) {
                         // Get Until
                         $until = strtotime($rrules['UNTIL']);
+                        if ($until > strtotime('+' . $this->defaultSpan  . ' years')) {
+                            $until = strtotime('+' . $this->defaultSpan  . ' years');
+                        }
                     } elseif (isset($rrules['COUNT'])) {
                         $countOrig = (is_numeric($rrules['COUNT']) && $rrules['COUNT'] > 1) ? $rrules['COUNT'] : 0;
 


### PR DESCRIPTION
#218

iCal birthdays from iCloud have an until date til the year 4500. A link with a lot of birthdays is really demanding on the server memory. Is it possible to limit the rrule until to max at the defaultSpan?