### PR TITLE
Every week with interval 2 on monday don't work correct

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1469,7 +1469,7 @@ class ICal
                             }
 
                             // Get timestamp of first day of start week
-                            $weekRecurringTimestamp = (strcasecmp($initialStart->format('l'), $this->weekdays[$wkst]) === 0)
+                            $weekRecurringTimestamp = (strcasecmp($initialStart->format('l'), substr($this->weekdays[$wkst], 0, -3)) === 0)
                                 ? $startTimestamp
                                 : strtotime("last {$days[$wkst]} " . $initialStart->format('H:i:s'), $startTimestamp);
 


### PR DESCRIPTION
### Description of the Issue:

With this weekly event on monday with an interval of 2, the parser create the following events: 1 july, 8 july, 15 july, 29 july. So the 8 july is not correct. I will create a pull request.

### Steps to Reproduce:

1. Create an ics with this event:

```
BEGIN:VEVENT
CREATED:20190630T065550Z
DTEND;TZID=Europe/Amsterdam:20190701T080000
DTSTAMP:20190630T143919Z
DTSTART;TZID=Europe/Amsterdam:20190701T070000
LAST-MODIFIED:20190630T143919Z
RRULE:FREQ=WEEKLY;INTERVAL=2
SEQUENCE:0
SUMMARY:Test event
UID:D86AB593-29D0-4523-A3B9-680BE46C729E
URL;VALUE=URI:
END:VEVENT
```

- https://www.ligon.nl/projects/testical.ics

1. Parse the recurring event and the dates above are generated.