### PR TITLE
Fix issues 197 & 208

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1173,29 +1173,19 @@ class ICal
         $dateArray = $event[$key . '_array'];
 
         if ($key === 'DURATION') {
-            $duration = end($dateArray);
-            $dateTime = $this->parseDuration($event['DTSTART'], $duration, null);
+            $dateTime = $this->parseDuration($event['DTSTART'], $dateArray[2], null);
         } else {
-            $dateTime = new \DateTime($dateArray[1], new \DateTimeZone(self::TIME_ZONE_UTC));
-            $dateTime->setTimezone(new \DateTimeZone($this->calendarTimeZone()));
+            // When constructing from a Unix Timestamp, no timezone needs passing.
+            $dateTime = new \DateTime('@' . $dateArray[2]);
         }
 
-        // Force time zone
-        if (isset($dateArray[0]['TZID'])) {
-            $dateTime->setTimezone($this->timeZoneStringToDateTimeZone($dateArray[0]['TZID']));
-        }
+        // Set the timezone we wish to use when running `$dateTime->format`.
+        $dateTime->setTimezone(new \DateTimeZone($this->calendarTimeZone()));
 
         if (is_null($format)) {
-            $output = $dateTime;
-        } else {
-            if ($format === self::UNIX_FORMAT) {
-                $output = $dateTime->getTimestamp();
-            } else {
-                $output = $dateTime->format($format);
-            }
+            return $dateTime;
         }
-
-        return $output;
+        return $dateTime->format($format);
     }
 
     /**
@@ -2043,8 +2033,8 @@ class ICal
                         $events[$key]['DTEND_tz'] = $this->iCalDateWithTimeZone($anEvent, 'DTEND');
                     } elseif ($this->iCalDateWithTimeZone($anEvent, 'DURATION')) {
                         $events[$key]['DTEND_tz'] = $this->iCalDateWithTimeZone($anEvent, 'DURATION');
-                    } elseif ($this->iCalDateWithTimeZone($anEvent, 'DTSTART')) {
-                        $events[$key]['DTEND_tz'] = $this->iCalDateWithTimeZone($anEvent, 'DTSTART');
+                    } else {
+                        $events[$key]['DTEND_tz'] = $events[$key]['DTSTART_tz'];
                     }
                 }
             }


### PR DESCRIPTION
This changeset should resolve both issues #197 and #208 (which are the same problem).

I have not added a test to `composer test`, as the files there are hard-coded to examine the contents of `DTSTART_array`, and modifying the test scripts to be able to test any (other) parameter is beyond the scope of this PR.

Instead, running the ICS fragments posted with the issues in question should be enough, with the following notes:

Issue #197:
- The expected value of `DTSTART_tz` should be "20181204T180000".
- Setting `$defaultTimezone` has no effect on this, as the ics-parser assumes that that the single `VTIMEZONE` given in the ics fragment is the calendar's time zone.
- If you change the `VTIMEZONE` statement (or remove it) so that the parser determines the calendar's time zone is "Europe/Copenhagen", then the expected value if `DTSTART_tz` would be "20181205T000000".

Issue #208:
- The second event in the provided ics fragment contains an RRULE that repeats daily for over a year and a half.
- Removing said event (so we don't have to check 500+ entries), the `DTSTART_tz` of the remaining events should be: '20190322T144500', '20190313T093000', '20190314T133000', '20190314T140000', '20190313T113000', '20190313T153000', '20190313T100000' in that order.
- (There is also an event later on that has RDATEs set, but we don't support those yet.)

----

The last chunk in this patch isn't necessary to this fix, but is related cleanup.