### PR TITLE
Use ISO Year within WEEKLY recurrence handling

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1397,7 +1397,7 @@ class ICal
                         foreach ($matchingDays as $day) {
                             $clonedDateTime = clone $frequencyRecurringDateTime;
                             $candidateDateTimes[] = $clonedDateTime->setISODate(
-                                $frequencyRecurringDateTime->format('Y'),
+                                $frequencyRecurringDateTime->format('o'),
                                 $frequencyRecurringDateTime->format('W'),
                                 $day
                             );


### PR DESCRIPTION
When setting the date for an occurrence of a recurring event where the `RRULE` has a frequency of `WEEKLY` and `BYDAY` was used, the `setISODate()` method is used.

Unfortunately, I had used `Y` instead of `o` as the date format code for getting the current year, thus feeding the Gregorian year instead of the ISO year into the method.

This was causing some year-start/end edge-case errors, as described in #251.

Essentially, I was committing the opposite of the error that Twitter is thought to have made in late 2014, as described in this video by Tom Scott: https://www.youtube.com/watch?v=D3jxx8Yyw1c (They should have used Gregorian and were using ISO, we should have been using ISO and were using Gregorian.)

----

Fixes #251 