### PR TITLE
Fix removing double event entries

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1229,7 +1229,7 @@ class ICal
 
             if (!empty($eventKeysToRemove)) {
                 foreach ($eventKeysToRemove as $eventKeyToRemove) {
-                    $events[$eventKeyToRemove] = null;
+                    unset($events[$eventKeyToRemove]);
                 }
             }
 


### PR DESCRIPTION
With PHP 7.4 I get the following error `Notice: Trying to access array offset on value of type null` when the ics file has duplicate event entries. Here the event really has to be removed and not set to `null`.