### PR TITLE
Skip empty lines

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -621,6 +621,10 @@ class ICal
                 if (!$this->disableCharacterReplacement) {
                     $line = $this->cleanData($line);
                 }
+                
+                if (empty($line)) {
+                    continue;
+                }
 
                 $add = $this->keyValueFromString($line);
 


### PR DESCRIPTION
Google Calendar public ICS calendars have an empty line at the end of the file and `ics-parser` tries to parse it into an key:value array.

```
  1   Illuminate\Foundation\Bootstrap\HandleExceptions::handleError("Trying to access array offset on value of type bool", "/vendor/johngrogg/ics-parser/src/ICal/ICal.php")
      /vendor/johngrogg/ics-parser/src/ICal/ICal.php:627
```