### PR TITLE
Accept any line endings in initString()

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -543,8 +543,9 @@ class ICal
      */
     public function initString($string)
     {
+        $string = str_replace(["\r\n", "\n\r", "\r"], "\n", $string);
         if (empty($this->cal)) {
-            $lines = explode(PHP_EOL, $string);
+            $lines = explode("\n", $string);
 
             $this->initLines($lines);
         } else {


### PR DESCRIPTION
$string can come from any external source and may use any line endings, not necessarily the ones used by our system

(using PHP_EOL for the string with other line endings will simply not result in exploding the string at all)