### PR TITLE
Remove "Carbon" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "ext-mbstring": "*",
-        "nesbot/carbon": "^1.39.0 || ^2.0"
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.9.1",

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -13,8 +13,6 @@
 
 namespace ICal;
 
-use Carbon\Carbon;
-
 class ICal
 {
     // phpcs:disable Generic.Arrays.DisallowLongArraySyntax
@@ -2199,7 +2197,7 @@ class ICal
         }
 
         $output          = array();
-        $currentTimeZone = $this->defaultTimeZone;
+        $currentTimeZone = new \DateTimeZone($this->defaultTimeZone);
 
         foreach ($exdates as $subArray) {
             end($subArray);
@@ -2212,14 +2210,14 @@ class ICal
                     $icalDate = $subArray[$key];
 
                     if (substr($icalDate, -1) === 'Z') {
-                        $currentTimeZone = self::TIME_ZONE_UTC;
+                        $currentTimeZone = new \DateTimeZone(self::TIME_ZONE_UTC);
                     }
 
-                    $output[] = new Carbon($icalDate, $currentTimeZone);
+                    $output[] = new \DateTime($icalDate, $currentTimeZone);
 
                     if ($key === $finalKey) {
                         // Reset to default
-                        $currentTimeZone = $this->defaultTimeZone;
+                        $currentTimeZone = new \DateTimeZone($this->defaultTimeZone);
                     }
                 }
             }

--- a/tests/RecurrencesTest.php
+++ b/tests/RecurrencesTest.php
@@ -295,6 +295,32 @@ class RecurrencesTest extends TestCase
         );
     }
 
+    public function testExdatesInDifferentTimezone()
+    {
+        $checks = array(
+            array('index' => 0, 'dateString' => '20170503T190000', 'message' => '1st event: '),
+            array('index' => 1, 'dateString' => '20170510T190000', 'message' => '2nd event: '),
+            array('index' => 9, 'dateString' => '20170712T190000', 'message' => '10th event: '),
+            array('index' => 19, 'dateString' => '20171004T190000', 'message' => '20th event: '),
+        );
+        $this->assertVEVENT(
+            'America/Chicago',
+            array(
+                'DTSTART;TZID=America/Chicago:20170503T190000',
+                'RRULE:FREQ=WEEKLY;BYDAY=WE;WKST=SU;UNTIL=20180101',
+                'EXDATE:20170601T000000Z',
+                'EXDATE:20170803T000000Z',
+                'EXDATE:20170824T000000Z',
+                'EXDATE:20171026T000000Z',
+                'EXDATE:20171102T000000Z',
+                'EXDATE:20171123T010000Z',
+                'EXDATE:20171221T010000Z'
+            ),
+            28,
+            $checks
+        );
+    }
+
     public function assertVEVENT($defaultTimezone, $veventParts, $count, $checks)
     {
         $options = $this->getOptions($defaultTimezone);


### PR DESCRIPTION
The reasoning being that the `Carbon` dependency was only being used in one method.

Included with this PR is a test based on the original issue (#161) that led to `Carbon` being used in the first place.

What *isn't* included is a regeneration of the `composer.lock` file. This is partly to make this PR smaller, but also because regenerating it causes the information about some of the other dependencies to be updated - to include it would be to include changes beyond the scope of this PR.