### PR TITLE
Fix ancient http/1.0 protocol

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nystudio107/ics-parser",
+    "name": "johngrogg/ics-parser",
     "description": "ICS Parser",
     "homepage": "https://github.com/u01jmg3/ics-parser",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "johngrogg/ics-parser",
+    "name": "nystudio107/ics-parser",
     "description": "ICS Parser",
     "homepage": "https://github.com/u01jmg3/ics-parser",
     "keywords": [

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -2570,9 +2570,9 @@ class ICal
     protected function fileOrUrl($filename)
     {
         $options = array();
+        $options['http'] = array();
+        $options['http']['header'] = array();
         if (!empty($this->httpBasicAuth) || !empty($this->httpUserAgent) || !empty($this->httpAcceptLanguage)) {
-            $options['http'] = array();
-            $options['http']['header'] = array();
 
             if (!empty($this->httpBasicAuth)) {
                 $username  = $this->httpBasicAuth['username'];
@@ -2590,6 +2590,9 @@ class ICal
                 array_push($options['http']['header'], "Accept-language: {$this->httpAcceptLanguage}");
             }
         }
+        // Defaults to http/1.0, which is ancient; bump it up to http/1.1
+        $options['http']['protocol_version'] = '1.1';
+        array_push($options['http']['header'], 'Connection: close');
 
         $context = stream_context_create($options);
 


### PR DESCRIPTION
This fixes the `fileOrUrl()` method so that it passes down `1.1` as the protocol to stream_context_create()` to allow the library to work with services that are deprecating `http/1.0`

ref: https://github.com/u01jmg3/ics-parser/issues/273