### PR TITLE
remove trailing counts for tz with same name introduced by some calendar apps

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -2618,7 +2618,9 @@ class ICal
         // but are within quoted texts. We need to remove the quotes as they're not
         // actually part of the time zone.
         $timeZoneString = trim($timeZoneString, '"');
-        $timeZoneString = html_entity_decode($timeZoneString);
+        $timeZoneString = html_entity_decode($timeZoneString);     
+        // remove trailing counts for tz with same name introduced by some calendar apps
+        $timeZoneString = trim(preg_replace('/\d/', '', $timeZoneString));
 
         if ($this->isValidIanaTimeZoneId($timeZoneString)) {
             return new \DateTimeZone($timeZoneString);


### PR DESCRIPTION
Some calendar apps using different names for the same timezone like:

```
DTSTART;TZID=W. Europe Standard Time 2:20210112T170000
DTEND;TZID=W. Europe Standard Time 2:20210112T190000
```