### PR TITLE
Support the MONTHLY rrule stanza by itself

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1476,6 +1476,8 @@ class ICal
                             }
                         } elseif (!empty($rrules['BYDAY'])) {
                             $matchingDays = $this->getDaysOfMonthMatchingByDayRRule($rrules['BYDAY'], $frequencyRecurringDateTime);
+                        } else {
+                            $matchingDays[] = $frequencyRecurringDateTime->format('d');
                         }
 
                         if (!empty($rrules['BYSETPOS'])) {


### PR DESCRIPTION
Currently, attempting to use a `MONTHLY` `RRULE` without any `BY{*}` modifiers (e.g. `FREQ=MONTHLY;COUNT=4`) results in no recurrences being generated.

This PR fixes that oversight.