### PR TITLE
Handle MONTHLY rrules with BYDAY set as the [-]5th instance of a weekday

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1771,10 +1771,14 @@ class ICal
 
             if ($ordwk < 0) { // -ve {ordwk}
                 $bydayDateTime->modify((++$ordwk) . ' week');
-                $matchingDays[] = $bydayDateTime->format('j');
+                if ($bydayDateTime->format('n') === $initialDateTime->format('n')) {
+                    $matchingDays[] = $bydayDateTime->format('j');
+                }
             } elseif ($ordwk > 0) { // +ve {ordwk}
                 $bydayDateTime->modify((--$ordwk) . ' week');
-                $matchingDays[] = $bydayDateTime->format('j');
+                if ($bydayDateTime->format('n') === $initialDateTime->format('n')) {
+                    $matchingDays[] = $bydayDateTime->format('j');
+                }
             } else { // No {ordwk}
                 while ($bydayDateTime->format('n') === $initialDateTime->format('n')) {
                     $matchingDays[] = $bydayDateTime->format('j');

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1385,8 +1385,8 @@ class ICal
 
             if (isset($rrules['UNTIL'])) {
                 $untilDT = $this->iCalDateToDateTime($rrules['UNTIL']);
-                $until = min($until, $untilDT->getTimestamp());
-            
+                $until   = min($until, $untilDT->getTimestamp());
+
                 // There are certain edge cases where we need to go a little beyond the UNTIL to
                 // ensure we get all events. Consider:
                 //

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -1753,6 +1753,7 @@ class ICal
     protected function getDaysOfMonthMatchingByDayRRule(array $byDays, $initialDateTime)
     {
         $matchingDays = array();
+        $currentMonth = $initialDateTime->format('n');
 
         foreach ($byDays as $weekday) {
             $bydayDateTime = clone $initialDateTime;
@@ -1771,12 +1772,12 @@ class ICal
 
             if ($ordwk < 0) { // -ve {ordwk}
                 $bydayDateTime->modify((++$ordwk) . ' week');
-                if ($bydayDateTime->format('n') === $initialDateTime->format('n')) {
+                if ($bydayDateTime->format('n') === $currentMonth) {
                     $matchingDays[] = $bydayDateTime->format('j');
                 }
             } elseif ($ordwk > 0) { // +ve {ordwk}
                 $bydayDateTime->modify((--$ordwk) . ' week');
-                if ($bydayDateTime->format('n') === $initialDateTime->format('n')) {
+                if ($bydayDateTime->format('n') === $currentMonth) {
                     $matchingDays[] = $bydayDateTime->format('j');
                 }
             } else { // No {ordwk}

--- a/tests/RecurrencesTest.php
+++ b/tests/RecurrencesTest.php
@@ -452,6 +452,32 @@ class RecurrencesTest extends TestCase
         );
     }
 
+    public function test5thByDayOfMonth()
+    {
+        $checks = array(
+            array('index' => 0, 'dateString' => '20200103T090000', 'message' => '1st event: '),
+            array('index' => 1, 'dateString' => '20200129T090000', 'message' => '2nd event: '),
+            array('index' => 2, 'dateString' => '20200429T090000', 'message' => '3rd event: '),
+            array('index' => 3, 'dateString' => '20200501T090000', 'message' => '4th event: '),
+            array('index' => 4, 'dateString' => '20200703T090000', 'message' => '5th event: '),
+            array('index' => 5, 'dateString' => '20200729T090000', 'message' => '6th event: '),
+            array('index' => 6, 'dateString' => '20200930T090000', 'message' => '7th event: '),
+            array('index' => 7, 'dateString' => '20201002T090000', 'message' => '8th event: '),
+            array('index' => 8, 'dateString' => '20201230T090000', 'message' => '9th event: '),
+            //array('index' => 9, 'dateString' => '20210101T090000', 'message' => '10th and last event: '),
+        );
+        $this->assertVEVENT(
+            'UTC',
+            array(
+                'DTSTART:20200103T090000',
+                'DTEND:20200103T100000',
+                'RRULE:FREQ=MONTHLY;BYDAY=5WE,-5FR;UNTIL=20210102T090000',
+            ),
+            9,
+            $checks
+        );
+    }
+
     public function assertVEVENT($defaultTimezone, $veventParts, $count, $checks)
     {
         $options = $this->getOptions($defaultTimezone);

--- a/tests/RecurrencesTest.php
+++ b/tests/RecurrencesTest.php
@@ -464,7 +464,7 @@ class RecurrencesTest extends TestCase
             array('index' => 6, 'dateString' => '20200930T090000', 'message' => '7th event: '),
             array('index' => 7, 'dateString' => '20201002T090000', 'message' => '8th event: '),
             array('index' => 8, 'dateString' => '20201230T090000', 'message' => '9th event: '),
-            //array('index' => 9, 'dateString' => '20210101T090000', 'message' => '10th and last event: '),
+            array('index' => 9, 'dateString' => '20210101T090000', 'message' => '10th and last event: '),
         );
         $this->assertVEVENT(
             'UTC',
@@ -473,7 +473,7 @@ class RecurrencesTest extends TestCase
                 'DTEND:20200103T100000',
                 'RRULE:FREQ=MONTHLY;BYDAY=5WE,-5FR;UNTIL=20210102T090000',
             ),
-            9,
+            10,
             $checks
         );
     }


### PR DESCRIPTION
As reported in #324, requesting the 5th (or -5th) Monday/Tuesday/whatever of a month was returning erroneous dates caused by overlapping into the next (or previous) month.

There was also a related edge case, where the very last occurrence sometimes wasn't being generated. Consider the following input:
```
DTSTART:20200103
RRULE:FREQ=MONTHLY;BYDAY=-5FR;UNTIL=20200502
```

The last date generated should be the 1st of May, however running this with the parser (with the patch from #324), this date is not output.

The code essentially does this (pseudo):
```
$until = {RRULE UNTIL};
$currentdate = {DTSTART};

while ($currentdate <= $until) {
    generate_occurrences();
    if (any occurrences <= $until)
        add_occurrence_to_output();
    $currentdate += 1 month;
}
```

After transitioning from April 3rd to May 3rd, we find that as 3rd May (`$currentdate`) is after the 2nd May (`$until`) the loop exits, without generating any May occurrences for consideration.

The solution given in this PR is to use a new `$untilWhile` variable that is one `$frequencyInterval` (in this case one month) later along than `$until`, and use that in the while loop conditional statement. (Whilst still using `$until` to check each individual candidate occurrence.)

----

Initial fix provided by @room34

Fixes #324