### PR TITLE
Update Event.php phpdoc

### DIFF
--- a/src/ICal/Event.php
+++ b/src/ICal/Event.php
@@ -32,7 +32,7 @@ class Event
     /**
      * https://www.kanzaki.com/docs/ical/duration.html
      *
-     * @var string
+     * @var string|null
      */
     public $duration;
 
@@ -81,14 +81,14 @@ class Event
     /**
      * https://www.kanzaki.com/docs/ical/description.html
      *
-     * @var string
+     * @var string|null
      */
     public $description;
 
     /**
      * https://www.kanzaki.com/docs/ical/location.html
      *
-     * @var string
+     * @var string|null
      */
     public $location;
 


### PR DESCRIPTION
Properties duration, description, and location can also be null, as I discovered when working with ICS data from Google Calendar. Inaccurate PHPDoc caused issues with PHPStan