### PR TITLE
Change Event additionalProperties to public

### DIFF
--- a/src/ICal/Event.php
+++ b/src/ICal/Event.php
@@ -132,7 +132,7 @@ class Event
      *
      * @var array<string, mixed>
      */
-    private $additionalProperties = array();
+    public $additionalProperties = array();
 
     /**
      * Creates the Event object


### PR DESCRIPTION
Changes Event's `$additionalProperties` visibility to public so its values can be iterated.

Fixes #329