### PR TITLE
Add the information that states that the datas were successfully parsed

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -113,6 +113,13 @@ class ICal
     public $cal = array();
 
     /**
+     * `true` if some lines were parsed
+     *
+     * @var boolean
+     */
+    public $contentParsed = false;
+
+    /**
      * Tracks the VFREEBUSY component
      *
      * @var integer
@@ -775,6 +782,8 @@ class ICal
             }
 
             $this->processDateConversions();
+
+            $this->contentParsed = true;
         }
     }
 

--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -634,6 +634,7 @@ class ICal
      */
     protected function initLines(array $lines)
     {
+        $this->contentParsed = false;
         $lines = $this->unfold($lines);
 
         if (stristr($lines[0], 'BEGIN:VCALENDAR') !== false) {


### PR DESCRIPTION
Similar to #336 but just validating that some content has been parsed and no error has been thrown.
Without this, there's no way to distinguish the state of the parser before and after parsing happened.
Another idea could be to set $cal property to null before parsing but this would be a BC.