### PR TITLE
[Fix #350] Add null check for timezone_id in ICal.php

### DIFF
--- a/src/ICal/ICal.php
+++ b/src/ICal/ICal.php
@@ -2417,7 +2417,9 @@ class ICal
 
         foreach ($tza as $zone) {
             foreach ($zone as $item) {
-                $valid[$item['timezone_id']] = true;
+                if ($item['timezone_id'] !== null) {
+                    $valid[$item['timezone_id']] = true;
+                }
             }
         }
 


### PR DESCRIPTION
This PR (as requested) aims to fix #350 